### PR TITLE
feat: Integrate React Compiler

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import react from "@vitejs/plugin-react";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import { defineConfig } from "vite";
 import viteCompression from "vite-plugin-compression";
@@ -7,14 +8,14 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  esbuild: {
-    jsxFactory: 'React.createElement',
-    jsxFragment: 'React.Fragment',
-    jsxInject: 'import React from \'react\'',
-  },
   plugins: [
     tsConfigPaths({
       projects: ["./tsconfig.json"],
+    }),
+    react({
+      babel: {
+        plugins: [["babel-plugin-react-compiler", {}]],
+      },
     }),
     tanstackStart({
       target: "netlify",


### PR DESCRIPTION
- Updated vite.config.ts to use @vitejs/plugin-react with babel-plugin-react-compiler.
- Removed manual esbuild JSX configuration as it's handled by the plugin.
- Ensured bun installation and project dependencies are set up.